### PR TITLE
Added GIT_SYNC_ONE_TIME environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ docker run --name git-sync -d  \
     -e GIT_SYNC_BRANCH=master \
     -e GIT_SYNC_REV=FETCH_HEAD \
     -e GIT_SYNC_WAIT=10 \
+    -e GIT_SYNC_ONE_TIME=false \
     -v website_sources:/git openweb/git-sync:0.0.1
 
 docker run --name nginx \


### PR DESCRIPTION
When true, fetch only happens once and program terminates.
When false, fetch happens continually, as before, using the GIT_SYNC_WAIT environment variable as a polling interval.

Thank you @cmerris-inmoment for doing this!  I hope upstream pulls it in someday!